### PR TITLE
perf: optimise `encodeRandom()` (10x improvement)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,13 +114,12 @@ deno bench
 ```
 
 ```
-cpu: Apple M1
-runtime: deno 1.34.1 (aarch64-apple-darwin)
+cpu: Apple M2
+runtime: deno 1.36.0 (aarch64-apple-darwin)
 
-file:///Users/kt3k/oss/ulid/bench.ts
-benchmark         time (avg)             (min … max)       p75       p99      p995
----------------------------------------------------- -----------------------------
-encodeTime    378.13 ns/iter(324.22 ns … 432.38 ns) 387.6 ns 418.98 ns 432.38 ns
-encodeRandom  1.72 µs/iter(1.68 µs … 1.79 µs) 1.74 µs 1.79 µs 1.79 µs
-generate      3.08 µs/iter(3.03 µs … 3.32 µs) 3.07 µs 3.32 µs 3.32 µs
+benchmark         time (avg)        iter/s             (min … max)       p75       p99      p995
+------------------------------------------------------------------ -----------------------------
+encodeTime       303.42 ns/iter   3,295,776.1  (299.3 ns … 330.98 ns) 304.59 ns 326.78 ns 330.98 ns
+encodeRandom     577.64 ns/iter   1,731,186.6 (337.92 ns … 738.33 ns) 640.61 ns 738.33 ns 738.33 ns
+generate         670.84 ns/iter   1,490,678.9 (612.39 ns … 721.08 ns) 694.94 ns 721.08 ns 721.08 ns
 ```

--- a/deno.lock
+++ b/deno.lock
@@ -1,0 +1,37 @@
+{
+  "version": "2",
+  "remote": {
+    "https://deno.land/std@0.190.0/fmt/colors.ts": "d67e3cd9f472535241a8e410d33423980bec45047e343577554d3356e1f0ef4e",
+    "https://deno.land/std@0.190.0/testing/_diff.ts": "1a3c044aedf77647d6cac86b798c6417603361b66b54c53331b312caeb447aea",
+    "https://deno.land/std@0.190.0/testing/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
+    "https://deno.land/std@0.190.0/testing/asserts.ts": "e16d98b4d73ffc4ed498d717307a12500ae4f2cbe668f1a215632d19fcffc22f"
+  },
+  "npm": {
+    "specifiers": {
+      "@types/node": "@types/node@18.16.18",
+      "lolex": "lolex@6.0.0"
+    },
+    "packages": {
+      "@sinonjs/commons@1.8.6": {
+        "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
+        "dependencies": {
+          "type-detect": "type-detect@4.0.8"
+        }
+      },
+      "@types/node@18.16.18": {
+        "integrity": "sha512-/aNaQZD0+iSBAGnvvN2Cx92HqE5sZCPZtx2TsK+4nvV23fFe09jVDvpArXr2j9DnYlzuU9WuoykDDc6wqvpNcw==",
+        "dependencies": {}
+      },
+      "lolex@6.0.0": {
+        "integrity": "sha512-ad9IBHbfVJ3bPAotDxnCgJgKcNK5/mrRAfbJzXhY5+PEmuBWP7wyHQlA6L8TfSfPlqlDjY4K7IG6mbzsrIBx1A==",
+        "dependencies": {
+          "@sinonjs/commons": "@sinonjs/commons@1.8.6"
+        }
+      },
+      "type-detect@4.0.8": {
+        "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+        "dependencies": {}
+      }
+    }
+  }
+}

--- a/mod.ts
+++ b/mod.ts
@@ -90,11 +90,7 @@ export function encodeTime(now: number, len: number = TIME_LEN): string {
 }
 
 export function encodeRandom(len: number, prng: PRNG): string {
-  let str = "";
-  for (; len > 0; len--) {
-    str = randomChar(prng) + str;
-  }
-  return str;
+  return randomChar(prng).repeat(len);
 }
 
 export function decodeTime(id: string): number {


### PR DESCRIPTION
This change improves the performance of `encodeRandom()` and ULID generation by 10x.

Before:
```
cpu: Apple M2
runtime: deno 1.36.0 (aarch64-apple-darwin)

benchmark         time (avg)        iter/s             (min … max)       p75       p99      p995
------------------------------------------------------------------ -----------------------------
encodeTime       302.74 ns/iter   3,303,187.7  (298.18 ns … 334.8 ns) 303.59 ns 329.95 ns  334.8 ns
encodeRandom       5.83 µs/iter     171,409.6     (5.21 µs … 6.27 µs)   6.11 µs   6.27 µs   6.27 µs
generate           9.39 µs/iter     106,460.0     (9.08 µs … 9.68 µs)   9.57 µs   9.68 µs   9.68 µs
```

After:
```
cpu: Apple M2
runtime: deno 1.36.0 (aarch64-apple-darwin)
benchmark         time (avg)        iter/s             (min … max)       p75       p99      p995
------------------------------------------------------------------ -----------------------------
encodeTime       303.42 ns/iter   3,295,776.1  (299.3 ns … 330.98 ns) 304.59 ns 326.78 ns 330.98 ns
encodeRandom     577.64 ns/iter   1,731,186.6 (337.92 ns … 738.33 ns) 640.61 ns 738.33 ns 738.33 ns
generate         670.84 ns/iter   1,490,678.9 (612.39 ns … 721.08 ns) 694.94 ns 721.08 ns 721.08 ns
```