### PR TITLE
refactor: replace `.substr()` with `.substring()`

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,0 +1,37 @@
+{
+  "version": "2",
+  "remote": {
+    "https://deno.land/std@0.190.0/fmt/colors.ts": "d67e3cd9f472535241a8e410d33423980bec45047e343577554d3356e1f0ef4e",
+    "https://deno.land/std@0.190.0/testing/_diff.ts": "1a3c044aedf77647d6cac86b798c6417603361b66b54c53331b312caeb447aea",
+    "https://deno.land/std@0.190.0/testing/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
+    "https://deno.land/std@0.190.0/testing/asserts.ts": "e16d98b4d73ffc4ed498d717307a12500ae4f2cbe668f1a215632d19fcffc22f"
+  },
+  "npm": {
+    "specifiers": {
+      "@types/node": "@types/node@18.16.18",
+      "lolex": "lolex@6.0.0"
+    },
+    "packages": {
+      "@sinonjs/commons@1.8.6": {
+        "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
+        "dependencies": {
+          "type-detect": "type-detect@4.0.8"
+        }
+      },
+      "@types/node@18.16.18": {
+        "integrity": "sha512-/aNaQZD0+iSBAGnvvN2Cx92HqE5sZCPZtx2TsK+4nvV23fFe09jVDvpArXr2j9DnYlzuU9WuoykDDc6wqvpNcw==",
+        "dependencies": {}
+      },
+      "lolex@6.0.0": {
+        "integrity": "sha512-ad9IBHbfVJ3bPAotDxnCgJgKcNK5/mrRAfbJzXhY5+PEmuBWP7wyHQlA6L8TfSfPlqlDjY4K7IG6mbzsrIBx1A==",
+        "dependencies": {
+          "@sinonjs/commons": "@sinonjs/commons@1.8.6"
+        }
+      },
+      "type-detect@4.0.8": {
+        "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+        "dependencies": {}
+      }
+    }
+  }
+}

--- a/mod.ts
+++ b/mod.ts
@@ -28,7 +28,7 @@ const TIME_LEN = 10;
 const RANDOM_LEN = 16;
 
 export function replaceCharAt(str: string, index: number, char: string) {
-  return str.substr(0, index) + char + str.substr(index + 1);
+  return str.substring(0, index) + char + str.substring(index + 1);
 }
 
 export function incrementBase32(str: string): string {

--- a/mod.ts
+++ b/mod.ts
@@ -31,7 +31,7 @@ export function replaceCharAt(str: string, index: number, char: string) {
   if (index > str.length - 1) {
     return str;
   }
-  return str.substr(0, index) + char + str.substr(index + 1);
+  return str.substring(0, index) + char + str.substring(index + 1);
 }
 
 export function incrementBase32(str: string): string {
@@ -102,7 +102,7 @@ export function decodeTime(id: string): number {
     throw createError("malformed ulid");
   }
   const time = id
-    .substr(0, TIME_LEN)
+    .substring(0, TIME_LEN)
     .split("")
     .reverse()
     .reduce((carry, char, index) => {


### PR DESCRIPTION
[`.substr()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated.