### PR TITLE
perf: replace `detectPrng()` with `Math.random()` (up to 35x improvement)

### DIFF
--- a/bench.ts
+++ b/bench.ts
@@ -3,14 +3,12 @@
 
 import * as ulid from "./mod.ts";
 
-const prng = ulid.detectPrng();
-
 Deno.bench("encodeTime", function () {
   ulid.encodeTime(1469918176385);
 });
 
 Deno.bench("encodeRandom", function () {
-  ulid.encodeRandom(10, prng);
+  ulid.encodeRandom(10, Math.random);
 });
 
 Deno.bench("generate", function () {

--- a/deno.lock
+++ b/deno.lock
@@ -1,0 +1,37 @@
+{
+  "version": "2",
+  "remote": {
+    "https://deno.land/std@0.190.0/fmt/colors.ts": "d67e3cd9f472535241a8e410d33423980bec45047e343577554d3356e1f0ef4e",
+    "https://deno.land/std@0.190.0/testing/_diff.ts": "1a3c044aedf77647d6cac86b798c6417603361b66b54c53331b312caeb447aea",
+    "https://deno.land/std@0.190.0/testing/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
+    "https://deno.land/std@0.190.0/testing/asserts.ts": "e16d98b4d73ffc4ed498d717307a12500ae4f2cbe668f1a215632d19fcffc22f"
+  },
+  "npm": {
+    "specifiers": {
+      "@types/node": "@types/node@18.16.18",
+      "lolex": "lolex@6.0.0"
+    },
+    "packages": {
+      "@sinonjs/commons@1.8.6": {
+        "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
+        "dependencies": {
+          "type-detect": "type-detect@4.0.8"
+        }
+      },
+      "@types/node@18.16.18": {
+        "integrity": "sha512-/aNaQZD0+iSBAGnvvN2Cx92HqE5sZCPZtx2TsK+4nvV23fFe09jVDvpArXr2j9DnYlzuU9WuoykDDc6wqvpNcw==",
+        "dependencies": {}
+      },
+      "lolex@6.0.0": {
+        "integrity": "sha512-ad9IBHbfVJ3bPAotDxnCgJgKcNK5/mrRAfbJzXhY5+PEmuBWP7wyHQlA6L8TfSfPlqlDjY4K7IG6mbzsrIBx1A==",
+        "dependencies": {
+          "@sinonjs/commons": "@sinonjs/commons@1.8.6"
+        }
+      },
+      "type-detect@4.0.8": {
+        "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+        "dependencies": {}
+      }
+    }
+  }
+}

--- a/mod.ts
+++ b/mod.ts
@@ -118,6 +118,7 @@ export function decodeTime(id: string): number {
   return time;
 }
 
+/** @deprecated Use `Math.random()` instead */
 export function detectPrng(): PRNG {
   return () => {
     const buffer = new Uint8Array(1);
@@ -126,13 +127,13 @@ export function detectPrng(): PRNG {
   };
 }
 
-export function factory(prng: PRNG = detectPrng()): ULID {
+export function factory(prng: PRNG = Math.random): ULID {
   return function ulid(seedTime: number = Date.now()): string {
     return encodeTime(seedTime, TIME_LEN) + encodeRandom(RANDOM_LEN, prng);
   };
 }
 
-export function monotonicFactory(prng: PRNG = detectPrng()): ULID {
+export function monotonicFactory(prng: PRNG = Math.random): ULID {
   let lastTime = 0;
   let lastRandom: string;
   return function ulid(seedTime: number = Date.now()): string {

--- a/mod.ts
+++ b/mod.ts
@@ -116,13 +116,7 @@ export function decodeTime(id: string): number {
 }
 
 /** @deprecated Use `Math.random()` instead */
-export function detectPrng(): PRNG {
-  return () => {
-    const buffer = new Uint8Array(1);
-    crypto.getRandomValues(buffer);
-    return buffer[0] / 0xff;
-  };
-}
+export const detectPrng: PRNG = Math.random;
 
 export function factory(prng: PRNG = Math.random): ULID {
   return function ulid(seedTime: number = Date.now()): string {

--- a/mod.ts
+++ b/mod.ts
@@ -59,10 +59,7 @@ export function incrementBase32(str: string): string {
 }
 
 export function randomChar(prng: PRNG): string {
-  let rand = Math.floor(prng() * ENCODING_LEN);
-  if (rand === ENCODING_LEN) {
-    rand = ENCODING_LEN - 1;
-  }
+  const rand = Math.floor(prng() * ENCODING_LEN);
   return ENCODING.charAt(rand);
 }
 

--- a/test.ts
+++ b/test.ts
@@ -13,7 +13,7 @@ const ulid = ULID.factory();
 
 Deno.test("ulid", async (t) => {
   await t.step("prng", async (t) => {
-    const prng = ULID.detectPrng();
+    const prng = Math.random;
 
     await t.step("should produce a number", () => {
       assertEquals(false, isNaN(prng()));
@@ -50,7 +50,7 @@ Deno.test("ulid", async (t) => {
 
   await t.step("randomChar", async (t) => {
     const sample: Record<string, number> = {};
-    const prng = ULID.detectPrng();
+    const prng = Math.random;
 
     for (let x = 0; x < 320000; x++) {
       const char = String(ULID.randomChar(prng)); // for if it were to ever return undefined
@@ -117,7 +117,7 @@ Deno.test("ulid", async (t) => {
   });
 
   await t.step("encodeRandom", async (t) => {
-    const prng = ULID.detectPrng();
+    const prng = Math.random;
 
     await t.step("should return correct length", () => {
       assertEquals(12, ULID.encodeRandom(12, prng).length);


### PR DESCRIPTION
Before:
```
cpu: Apple M2
runtime: deno 1.36.0 (aarch64-apple-darwin)

benchmark         time (avg)        iter/s             (min … max)       p75       p99      p995
------------------------------------------------------------------ -----------------------------
encodeTime       300.29 ns/iter   3,330,128.9 (296.45 ns … 330.86 ns) 300.66 ns 324.57 ns 330.86 ns
encodeRandom       5.99 µs/iter     167,070.2     (5.11 µs … 6.23 µs)    6.1 µs   6.23 µs   6.23 µs
generate           9.34 µs/iter     107,032.5      (8.89 µs … 9.8 µs)   9.61 µs    9.8 µs    9.8 µs
```

After:
```
cpu: Apple M2
runtime: deno 1.36.0 (aarch64-apple-darwin)

benchmark         time (avg)        iter/s             (min … max)       p75       p99      p995
------------------------------------------------------------------ -----------------------------
encodeTime       302.69 ns/iter   3,303,729.1 (298.42 ns … 367.81 ns) 301.97 ns 349.85 ns 367.81 ns
encodeRandom     169.59 ns/iter   5,896,426.9 (163.32 ns … 187.17 ns) 169.97 ns  179.3 ns 183.08 ns
generate         552.36 ns/iter   1,810,418.6  (544.5 ns … 590.55 ns) 554.15 ns 582.75 ns 590.55 ns
```